### PR TITLE
[Server] feat : 레시피 조회시, 메인 재료 여부를 확인할 수 있습니다.

### DIFF
--- a/Server/banchango/Dockerfile
+++ b/Server/banchango/Dockerfile
@@ -13,4 +13,3 @@ COPY ${JAR_FILE} /banchango.jar
 #컨테이너 실행 명령어
 #ex) java -jar -Dspring.profiles.active=prod /sejongmate.jar
 ENTRYPOINT ["java","-jar","/banchango.jar"]
-#

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/config/SwaggerConfig.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/config/SwaggerConfig.java
@@ -21,8 +21,11 @@ public class SwaggerConfig {
         Server server = new Server();
         server.setUrl("https://backendu.com");
 
+        Server localServer = new Server();
+        localServer.setUrl("http://localhost:8080");
+
         return new OpenAPI()
                 .info(info)
-                .servers(List.of(server));
+                .servers(List.of(server, localServer));
     }
 }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/application/IngredientMatcher.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/application/IngredientMatcher.java
@@ -4,63 +4,84 @@ import com.sundaegukbap.banchango.container.domain.Container;
 import com.sundaegukbap.banchango.container.repository.ContainerRepository;
 import com.sundaegukbap.banchango.ingredient.domain.ContainerIngredient;
 import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
+import com.sundaegukbap.banchango.ingredient.domain.RecipeMainIngredient;
 import com.sundaegukbap.banchango.ingredient.domain.RecipeRequiringIngredient;
+import com.sundaegukbap.banchango.ingredient.dto.dto.IngredientDtos;
 import com.sundaegukbap.banchango.ingredient.repository.ContainerIngredientRepository;
+import com.sundaegukbap.banchango.ingredient.repository.RecipeMainIngredientRepository;
 import com.sundaegukbap.banchango.ingredient.repository.RecipeRequiringIngredientRepository;
 import com.sundaegukbap.banchango.recipe.domain.Recipe;
 import com.sundaegukbap.banchango.user.domain.User;
-import lombok.AllArgsConstructor;
-import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @AllArgsConstructor
 public class IngredientMatcher {
+
     private ContainerRepository containerRepository;
     private ContainerIngredientRepository containerIngredientRepository;
     private RecipeRequiringIngredientRepository recipeRequiringIngredientRepository;
+    private RecipeMainIngredientRepository recipeMainIngredientRepository;
 
-    public HashMap<String,List> checkIngredientRelation(User user, Recipe recipe){
+    public HashMap<String, List> checkIngredientRelation(User user, Recipe recipe) {
         List<Ingredient> havingIngredients = getAllIngredientsWithUser(user);
         List<Ingredient> requiringIngredients = getIngredientsWithRecipe(recipe);
 
         List<Ingredient> need = new ArrayList<>();
         List<Ingredient> have = new ArrayList<>();
 
-        for(Ingredient ri : requiringIngredients){
+        for (Ingredient ri : requiringIngredients) {
             boolean has = havingIngredients.contains(ri);
-            if(has)
+            if (has) {
                 have.add(ri);
-            else
+            } else {
                 need.add(ri);
+            }
         }
 
-        HashMap<String,List> result = new HashMap<>();
+        HashMap<String, List> result = new HashMap<>();
         result.put("need", need);
         result.put("have", have);
 
         return result;
     }
 
-    private List<Ingredient> getAllIngredientsWithUser(User user){
+    private List<Ingredient> getAllIngredientsWithUser(User user) {
         List<Container> containers = containerRepository.findAllByUser(user);
-        List<ContainerIngredient> containerIngredientList = containerIngredientRepository.findByContainerIn(containers);
+        List<ContainerIngredient> containerIngredientList = containerIngredientRepository.findByContainerIn(
+            containers);
         List<Ingredient> ingredients = containerIngredientList.stream()
-                .map(ContainerIngredient::getIngredient)
-                .collect(Collectors.toList());
+            .map(ContainerIngredient::getIngredient)
+            .collect(Collectors.toList());
 
         return ingredients;
     }
 
     private List<Ingredient> getIngredientsWithRecipe(Recipe recipe) {
-        List<RecipeRequiringIngredient> recipeRequiringIngredientList = recipeRequiringIngredientRepository.findAllByRecipe(recipe);
+        List<RecipeRequiringIngredient> recipeRequiringIngredientList = recipeRequiringIngredientRepository.findAllByRecipe(
+            recipe);
 
         return recipeRequiringIngredientList.stream()
-                .map(i -> i.getIngredient())
-                .collect(Collectors.toList());
+            .map(i -> i.getIngredient())
+            .collect(Collectors.toList());
+    }
+
+    public void resolveMainIngredient(Recipe recipe, IngredientDtos ingredients) {
+        List<RecipeMainIngredient> mainIngredients =
+            recipeMainIngredientRepository.findByRecipe(recipe);
+
+        ingredients.ingredientDtos().forEach(ingredientDto -> {
+            Long target = ingredientDto.getId();
+            mainIngredients.forEach(mainIngredient -> {
+                if (mainIngredient.getIngredient().getId().equals(target)) {
+                    ingredientDto.setIsMain(true);
+                }
+            });
+        });
     }
 }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/dto/dto/ContainerIngredientDto.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/dto/dto/ContainerIngredientDto.java
@@ -1,10 +1,7 @@
 package com.sundaegukbap.banchango.ingredient.dto.dto;
 
-import com.sundaegukbap.banchango.container.domain.Container;
 import com.sundaegukbap.banchango.container.dto.dto.ContainerDto;
 import com.sundaegukbap.banchango.ingredient.domain.ContainerIngredient;
-import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
-
 import java.time.LocalDateTime;
 
 public record ContainerIngredientDto(

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/dto/dto/IngredientDto.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/dto/dto/IngredientDto.java
@@ -1,19 +1,30 @@
 package com.sundaegukbap.banchango.ingredient.dto.dto;
 
 import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-public record IngredientDto(
-        Long id,
-        String name,
-        String kind,
-        String image
-) {
-    public static IngredientDto of(Ingredient ingredient){
+@AllArgsConstructor
+@Getter
+public class IngredientDto {
+
+    private Long id;
+    private String name;
+    private String kind;
+    private String image;
+    private boolean isMain;
+
+    public static IngredientDto of(Ingredient ingredient) {
         return new IngredientDto(
-                ingredient.getId(),
-                ingredient.getName(),
-                ingredient.getKind(),
-                ingredient.getImage()
+            ingredient.getId(),
+            ingredient.getName(),
+            ingredient.getKind(),
+            ingredient.getImage(),
+            false
         );
+    }
+
+    public void setIsMain(boolean isMain) {
+        this.isMain = isMain;
     }
 }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/dto/dto/IngredientDtos.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/dto/dto/IngredientDtos.java
@@ -1,16 +1,11 @@
 package com.sundaegukbap.banchango.ingredient.dto.dto;
 
-import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
-
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record IngredientDtos(
         List<IngredientDto> ingredientDtos
 ) {
-    public static IngredientDtos of(List<Ingredient> ingredientList){
-        return new IngredientDtos(ingredientList.stream()
-                .map(IngredientDto::of)
-                .collect(Collectors.toList()));
+    public static IngredientDtos of(List<IngredientDto> ingredientDtos){
+        return new IngredientDtos(ingredientDtos);
     }
 }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/repository/RecipeMainIngredientRepository.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ingredient/repository/RecipeMainIngredientRepository.java
@@ -1,0 +1,14 @@
+package com.sundaegukbap.banchango.ingredient.repository;
+
+import com.sundaegukbap.banchango.ingredient.domain.RecipeMainIngredient;
+import com.sundaegukbap.banchango.recipe.domain.Recipe;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeMainIngredientRepository extends JpaRepository<RecipeMainIngredient, Long> {
+
+    List<RecipeMainIngredient> findByRecipe(Recipe recipe);
+
+}

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/recipe/application/RecipeQueryService.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/recipe/application/RecipeQueryService.java
@@ -2,6 +2,8 @@ package com.sundaegukbap.banchango.recipe.application;
 
 import com.sundaegukbap.banchango.ingredient.application.IngredientMatcher;
 import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
+import com.sundaegukbap.banchango.ingredient.dto.dto.IngredientDto;
+import com.sundaegukbap.banchango.ingredient.dto.dto.IngredientDtos;
 import com.sundaegukbap.banchango.recipe.domain.Recipe;
 import com.sundaegukbap.banchango.recipe.domain.UserRecommendedRecipe;
 import com.sundaegukbap.banchango.recipe.dto.response.RecommendedRecipeResponse;
@@ -69,6 +71,17 @@ public class RecipeQueryService {
         List<Ingredient> have = ingredientRelation.get("have");
         List<Ingredient> need = ingredientRelation.get("need");
 
-        return RecommendedRecipeResponse.of(recipe, have, need);
+        IngredientDtos haveDtos = IngredientDtos.of(have.stream()
+            .map(IngredientDto::of)
+            .toList());
+
+        IngredientDtos needDtos = IngredientDtos.of(need.stream()
+            .map(IngredientDto::of)
+            .toList());
+
+        ingredientMatcher.resolveMainIngredient(recipe, haveDtos);
+        ingredientMatcher.resolveMainIngredient(recipe, needDtos);
+
+        return RecommendedRecipeResponse.of(recipe, haveDtos, needDtos);
     }
 }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/recipe/dto/response/RecommendedRecipeResponse.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/recipe/dto/response/RecommendedRecipeResponse.java
@@ -1,21 +1,20 @@
 package com.sundaegukbap.banchango.recipe.dto.response;
 
-import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
 import com.sundaegukbap.banchango.ingredient.dto.dto.IngredientDtos;
 import com.sundaegukbap.banchango.recipe.domain.Recipe;
 import com.sundaegukbap.banchango.recipe.dto.dto.RecipeDto;
 
-import java.util.List;
-
 public record RecommendedRecipeResponse(
-        RecipeDto recipe,
-        IngredientDtos have,
+    RecipeDto recipe,
+    IngredientDtos have,
+    IngredientDtos need) {
+
+    public static RecommendedRecipeResponse of(Recipe recipe, IngredientDtos have,
         IngredientDtos need) {
-    public static RecommendedRecipeResponse of(Recipe recipe, List<Ingredient> have, List<Ingredient> need){
         return new RecommendedRecipeResponse(
-                RecipeDto.of(recipe),
-                IngredientDtos.of(have),
-                IngredientDtos.of(need)
+            RecipeDto.of(recipe),
+            have,
+            need
         );
     }
 }


### PR DESCRIPTION
<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Android] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈
- closed: #59 

## ✨ PR 세부 내용
- IngredientDto 수정
- Recipe와 IngredientDtos를 넘겨 해당 레시피의 메인 재료일시, 명시한다.
- Dto는 최상위 Dto에 바로 매개변수로 넣어 만들기보다는 차근차근 만들어 나갑니다.
- 레시피 메인재료 데이터에 접근하는 Repository 생성

## ⌛ 소요 시간