### PR TITLE
[Server] fix : 카테고리를 지정하여 레시피를 추천 받는다.

### DIFF
--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ai/application/AiRecipeRecommendClient.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ai/application/AiRecipeRecommendClient.java
@@ -23,8 +23,8 @@ public class AiRecipeRecommendClient {
 
     @Transactional
     public List<Long> getRecommendedRecipesFromAI(RecipeCategory category, List<Ingredient> ingredientList) {
-        AiRecipeRecommendRequest request = AiRecipeRecommendRequest.of(ingredientList);
-        AiRecipeRecommendResponse response = restTemplate.postForObject(aiBaseUrl + "/recommend", request, AiRecipeRecommendResponse.class);
+        AiRecipeRecommendRequest request = AiRecipeRecommendRequest.of(category, ingredientList);
+        AiRecipeRecommendResponse response = restTemplate.postForObject(aiBaseUrl + "/category_recommend", request, AiRecipeRecommendResponse.class);
 
         return response.recommended_recipes();
     }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ai/dto/AiRecipeRecommendRequest.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ai/dto/AiRecipeRecommendRequest.java
@@ -2,17 +2,20 @@ package com.sundaegukbap.banchango.ai.dto;
 
 import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
 
+import com.sundaegukbap.banchango.recipe.domain.RecipeCategory;
 import java.util.List;
 import java.util.stream.Collectors;
 
 public record AiRecipeRecommendRequest(
-        List<Long> ingredients
+        List<Long> ingredients,
+        int topcategory,
+        String subcategory
 ) {
-    public static AiRecipeRecommendRequest of(List<Ingredient> ingredients) {
+    public static AiRecipeRecommendRequest of(RecipeCategory recipeCategory, List<Ingredient> ingredients) {
         List<Long> ingredientIds = ingredients.stream()
                 .map(Ingredient::getId)
                 .collect(Collectors.toList());
 
-        return new AiRecipeRecommendRequest(ingredientIds);
+        return new AiRecipeRecommendRequest(ingredientIds, recipeCategory.getTopCategory(), recipeCategory.getSubCategory());
     }
 }

--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/recipe/domain/RecipeCategory.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/recipe/domain/RecipeCategory.java
@@ -1,18 +1,50 @@
 package com.sundaegukbap.banchango.recipe.domain;
 
 public enum RecipeCategory {
-    전체,
-    간식,
-    기타,
-    다이어트,
-    도시락,
-    명절,
-    손님접대,
-    술안주,
-    야식,
-    이유식,
-    일상,
-    초스피드,
-    푸드스타일링,
-    해장
+    전체(0, "전체"),
+    밑반찬(1, "밑반찬"),
+    메인반찬(1, "메인반찬"),
+    국_탕(1, "국/탕"),
+    찌개(1, "찌개"),
+    디저트(1, "디저트"),
+    면_만두(1, "면/만두"),
+    밥_죽_떡(1, "밥/죽/떡"),
+    퓨전(1, "퓨전"),
+    김치_젓갈_장류(1, "김치/젓갈/장류"),
+    양념_소스_잼(1, "양념/소스/잼"),
+    양식(1, "양식"),
+    샐러드(1, "샐러드"),
+    스프(1, "스프"),
+    빵_과자(1, "빵/과자"),
+    과자_간식(1, "과자/간식"),
+    차_음료_술(1, "차/음료/술"),
+    일상(2, "일상"),
+    초스피드(2, "초스피드"),
+    손님접대(2, "손님접대"),
+    술안주(2, "술안주"),
+    다이어트(2, "다이어트"),
+    도시락(2, "도시락"),
+    영양식(2, "영양식"),
+    간식(2, "간식"),
+    야식(2, "야식"),
+    푸드스타일링(2, "푸드스타일링"),
+    해장(2, "해장"),
+    명절음식(2, "명절음식"),
+    이유식(2, "이유식");
+
+    private final int topCategory;
+    private final String subCategory;
+
+    RecipeCategory(int topCategory, String subCategory) {
+        this.topCategory = topCategory;
+        this.subCategory = subCategory;
+    }
+
+    public int getTopCategory() {
+        return topCategory;
+    }
+
+    public String getSubCategory() {
+        return subCategory;
+    }
 }

--- a/Server/banchango/src/main/resources/application.properties
+++ b/Server/banchango/src/main/resources/application.properties
@@ -5,4 +5,4 @@ spring.profiles.active=prod
 app.cors.allowedOrigins=https://backendu.com,http://34.222.135.30:8000,http://localhost:3000,http://localhost:8080
 app.oauth2.authorizedRedirectUris=https://backendu.com,http://34.222.135.30:8000,http://localhost:3000/oauth2/redirect,myandroidapp://oauth2/redirect,myiosapp://oauth2/redirect
 
-api.aiBaseUrl=http://34.222.135.30:8000
+api.aiBaseUrl=http://44.242.23.64:8000


### PR DESCRIPTION
- 특정 카테고리를 지정하여 레시피 추천을 받을 수 있습니다.
- ai 서버의 주소가 변경되었으므로, 이를 반영합니다.

<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Android] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #62 

## ✨ PR 세부 내용
- 카테고리 변경시, 카테고리와 소유한 재료에 맞는 레시피를 추천 받아와, 유저에게 추천될 레시피 목록을 갱신할 수 있어야 합니다.
- `전체`카테고리라면, 식자재 만으로 레시피를 추천 받습니다.
- 재료를 추가하거나 삭제할땐, "전체"카테고리를 기준으로 추천 레시피가 갱신됩니다.
- ai측 배포 주소가 변경되었으므로, 이를 반영합니다.

## ⌛ 소요 시간