### PR TITLE
[Server] fix : 전체 카테고리에서 레시피를 추천 받는다

### DIFF
--- a/Server/banchango/src/main/java/com/sundaegukbap/banchango/ai/application/AiRecipeRecommendClient.java
+++ b/Server/banchango/src/main/java/com/sundaegukbap/banchango/ai/application/AiRecipeRecommendClient.java
@@ -5,14 +5,14 @@ import com.sundaegukbap.banchango.ai.dto.AiRecipeRecommendResponse;
 import com.sundaegukbap.banchango.ingredient.domain.Ingredient;
 import com.sundaegukbap.banchango.recipe.domain.RecipeCategory;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.List;
-
 @Component
 public class AiRecipeRecommendClient {
+
     @Value("${api.aiBaseUrl}")
     private String aiBaseUrl;
     private final RestTemplate restTemplate;
@@ -22,10 +22,30 @@ public class AiRecipeRecommendClient {
     }
 
     @Transactional
-    public List<Long> getRecommendedRecipesFromAI(RecipeCategory category, List<Ingredient> ingredientList) {
+    public List<Long> getRecommendedRecipesFromAI(RecipeCategory category,
+        List<Ingredient> ingredientList) {
         AiRecipeRecommendRequest request = AiRecipeRecommendRequest.of(category, ingredientList);
-        AiRecipeRecommendResponse response = restTemplate.postForObject(aiBaseUrl + "/category_recommend", request, AiRecipeRecommendResponse.class);
+
+        AiRecipeRecommendResponse response;
+        if (category == RecipeCategory.전체) {
+            response = getRecipesOfAllCategories(request);
+        } else {
+            response = getRecipesOfSpecificCategories(request);
+        }
 
         return response.recommended_recipes();
+    }
+
+    private AiRecipeRecommendResponse getRecipesOfSpecificCategories(
+        AiRecipeRecommendRequest request) {
+        AiRecipeRecommendResponse response = restTemplate.postForObject(
+            aiBaseUrl + "/category_recommend", request, AiRecipeRecommendResponse.class);
+        return response;
+    }
+
+    private AiRecipeRecommendResponse getRecipesOfAllCategories(AiRecipeRecommendRequest request) {
+        AiRecipeRecommendResponse response = restTemplate.postForObject(
+            aiBaseUrl + "/recommend", request, AiRecipeRecommendResponse.class);
+        return response;
     }
 }


### PR DESCRIPTION
- 재료 추가/삭제시, 전체 카테고리 기준으로 레시피를 추천 받습니다.
- 카테고리를 특정하여 레시피를 추천받는 ai측 api와 카테고리를 지정하지 않고 레시피를 추천 받는 api가 다름에 따라, 메서드를 분리하였습니다.

<!--
PR 이름 컨벤션
[Server] feat: ~~(#issueNum)
[Android] feat: ~~(#issueNum)
[iOS] fix: ~~(#issueNum)
[AI] feat: ~~(#issueNum)
-->

##  📌 관련 이슈

- closed: #65 

## ✨ PR 세부 내용
[fix(AiRecipeRecommendClient) : 전체 카테고리에서 레시피를 추천 받는다](https://github.com/Sundae-Gukbap/Banchango-AI/commit/89088891e5a81fe2affe885060ed003e64697028) 

- 재료 추가/삭제시, 전체 카테고리 기준으로 레시피를 추천 받습니다.
- 카테고리를 특정하여 레시피를 추천받는 ai측 api와 카테고리를 지정하지 않고 레시피를 추천 받는 api가 다름에 따라, 메서드를 분리하였습니다.

## ⌛ 소요 시간